### PR TITLE
Adding ordyswap example

### DIFF
--- a/examples/ordyswap/.gitignore
+++ b/examples/ordyswap/.gitignore
@@ -1,0 +1,5 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.cache/**
+history.txt

--- a/examples/ordyswap/.vscode/settings.json
+++ b/examples/ordyswap/.vscode/settings.json
@@ -1,0 +1,5 @@
+
+{
+    "deno.enable": true,
+    "files.eol": "\n"
+}

--- a/examples/ordyswap/.vscode/tasks.json
+++ b/examples/ordyswap/.vscode/tasks.json
@@ -1,0 +1,18 @@
+
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "check contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet check"
+        },
+        {
+            "label": "test contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet test"
+        }
+    ]
+}

--- a/examples/ordyswap/Clarinet.toml
+++ b/examples/ordyswap/Clarinet.toml
@@ -1,0 +1,21 @@
+[project]
+name = 'clarity-examples-ordyswap'
+description = ''
+authors = []
+telemetry = false
+cache_dir = './.cache'
+
+[[project.requirements]]
+contract_id = 'SP1WN90HKT0E1FWCJT9JFPMC8YP7XGBGFNZGHRVZX.clarity-bitcoin'
+[contracts.ord-swap]
+path = 'contracts/ord-swap.clar'
+clarity_version = 1
+epoch = 2.0
+[repl.analysis]
+passes = ['check_checker']
+
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/examples/ordyswap/contracts/ord-swap.clar
+++ b/examples/ordyswap/contracts/ord-swap.clar
@@ -1,0 +1,221 @@
+;;                                 OrdinalSwap                               ;;
+;;                                                                           ;;
+;;              Trustless p2p atomic swaps between Ordinals and STX          ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;                                      
+;; This code is provided for educational purposes and has not been audited,
+;; or thoroughly tested. Use at your own risk.
+;; 
+;; Source: https://github.com/mechanismHQ/ordyswap
+;;
+;; WARNING
+;; This version of ordyswap should only be used with "Genesis" Ordinals, not
+;; Ordinals that have already been transferred.
+;;
+;; DESCRIPTION
+;; The basic flow is:
+;; 
+;; - Someone makes an offer on a specific Ordinal. They must know the seller's
+;;   STX address ahead of time
+;;        - This contract escrows the STX
+;; - Ordinal owner sends the Ordinal to specified BTC address made in the offer
+;; - Ordinal owner calls this contract with a transaction inclusion proof to 
+;;   show that they send the right Ordinal to the right address
+;; - This contract sends STX to the Ordinal owner
+
+
+
+;; Main map for storing offers
+(define-map offers-map uint {
+  txid: (buff 32),
+  index: uint,
+  amount: uint,
+  output: (buff 128),
+  sender: principal,
+  recipient: principal,
+})
+
+(define-map offers-accepted-map uint bool)
+;; mapping of offer -> block height
+(define-map offers-cancelled-map uint uint)
+(define-map offers-refunded-map uint bool)
+
+(define-data-var last-id-var uint u0)
+
+(define-constant ERR_TX_NOT_MINED (err u100))
+(define-constant ERR_INVALID_TX (err u101))
+(define-constant ERR_INVALID_OFFER (err u102))
+(define-constant ERR_OFFER_MISMATCH (err u103))
+(define-constant ERR_OFFER_ACCEPTED (err u104))
+(define-constant ERR_OFFER_CANCELLED (err u105))
+
+(define-public (create-offer
+    (txid (buff 32))
+    (index uint)
+    (amount uint)
+    (output (buff 128))
+    (recipient principal)
+  )
+  (let
+    (
+      (id (make-next-id))
+    )
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (map-insert offers-map id {
+      txid: txid,
+      index: index,
+      amount: amount,
+      output: output,
+      sender: tx-sender,
+      recipient: recipient,
+    })
+    (print {
+      topic: "new-offer",
+      offer: {
+        id: id,
+        txid: txid,
+        index: index,
+        amount: amount,
+        output: output,
+        sender: tx-sender,
+        recipient: recipient,
+      }
+    })
+    (ok id)
+  )
+)
+
+;; Helper function to validate the transfer of an Ordinal.
+;; 
+;; This function is validating:
+;; 
+;; - The transaction was mined in a BTC block
+;; - The transaction was sent to the right address
+;; - The transaction includes the right Ordinal as an input
+;; - The offer wasn't cancelled
+;; - The offer wasn't already accepted
+(define-read-only (validate-offer-transfer
+    (block { header: (buff 80), height: uint })
+    (prev-blocks (list 10 (buff 80)))
+    (tx (buff 1024))
+    (proof { tx-index: uint, hashes: (list 12 (buff 32)), tree-depth: uint })
+    (input-index uint)
+    (output-index uint)
+    (offer-id uint)
+  )
+  (let
+    (
+      (was-mined-bool (unwrap! (contract-call? 'SP1WN90HKT0E1FWCJT9JFPMC8YP7XGBGFNZGHRVZX.clarity-bitcoin was-tx-mined-prev? block prev-blocks tx proof) ERR_TX_NOT_MINED))
+      (was-mined (asserts! was-mined-bool ERR_TX_NOT_MINED))
+      (mined-height (get height block))
+      (parsed-tx (unwrap! (contract-call? 'SP1WN90HKT0E1FWCJT9JFPMC8YP7XGBGFNZGHRVZX.clarity-bitcoin parse-tx tx) ERR_INVALID_TX))
+      (output (unwrap! (element-at (get outs parsed-tx) output-index) ERR_INVALID_TX))
+      (offer (unwrap! (map-get? offers-map offer-id) ERR_INVALID_OFFER))
+      (input (get outpoint (unwrap! (element-at (get ins parsed-tx) input-index) ERR_INVALID_TX)))
+      (input-txid (get hash input))
+      (input-idx (get index input))
+    )
+    ;; Ensure that the right ordinal is being sent - based on the `{txid,index}`
+    (asserts! (is-eq input-txid (get txid offer)) ERR_OFFER_MISMATCH)
+    (asserts! (is-eq input-idx (get index offer)) ERR_OFFER_MISMATCH)
+    ;; Ensure it was sent to the right address
+    (asserts! (is-eq (get scriptPubKey output) (get output offer)) ERR_OFFER_MISMATCH)
+    ;; Ensure it hasn't been accepted
+    (asserts! (is-eq (map-get? offers-accepted-map offer-id) none) ERR_OFFER_ACCEPTED)
+    ;; Ensure it wasn't cancelled
+    (match (map-get? offers-cancelled-map offer-id)
+      cancelled-at (if (<= burn-block-height cancelled-at)
+        (ok offer)
+        ERR_OFFER_CANCELLED
+      )
+      (ok offer)
+    )
+  )
+)
+
+(define-public (finalize-offer
+    (block { header: (buff 80), height: uint })
+    (prev-blocks (list 10 (buff 80)))
+    (tx (buff 1024))
+    (proof { tx-index: uint, hashes: (list 12 (buff 32)), tree-depth: uint })
+    (output-index uint)
+    (input-index uint)
+    (offer-id uint)
+  )
+  (let
+    (
+      (offer (try! (validate-offer-transfer block prev-blocks tx proof input-index output-index offer-id)))
+    )
+    (try! (as-contract (stx-transfer? (get amount offer) (as-contract tx-sender) (get recipient offer))))
+    (asserts! (map-insert offers-accepted-map offer-id true) ERR_OFFER_ACCEPTED)
+    (print {
+      topic: "offer-finalized",
+      offer: (merge offer { id: offer-id }),
+      txid: (contract-call? 'SP1WN90HKT0E1FWCJT9JFPMC8YP7XGBGFNZGHRVZX.clarity-bitcoin get-txid tx)
+    })
+    (ok offer-id)
+  )
+)
+
+;; Cancel an offer
+;; 
+;; The Ordinal owner still has 50 blocks to send the ordinal. This
+;; prevents an attack where an offer is cancelled after the Ordinal transfer
+;; hits the mempool.
+(define-public (cancel-offer (id uint))
+  (let
+    (
+      (offer (unwrap! (map-get? offers-map id) ERR_INVALID_OFFER))
+    )
+    (asserts! (is-eq (get sender offer) tx-sender) ERR_INVALID_OFFER)
+    
+    (asserts! (map-insert offers-cancelled-map id (+ burn-block-height u50)) ERR_INVALID_OFFER)
+    (print {
+      topic: "offer-cancelled",
+      offer: (merge offer { id: id }),
+    })
+    (ok true)
+  )
+)
+
+;; 50+ blocks after cancelling, the offerer can get their STX back
+(define-public (refund-cancelled-offer (id uint))
+  (let
+    (
+      (offer (unwrap! (map-get? offers-map id) ERR_INVALID_OFFER))
+      (cancelled (unwrap! (map-get? offers-cancelled-map id) ERR_INVALID_OFFER))
+    )
+    (asserts! (> burn-block-height cancelled) ERR_INVALID_OFFER)
+    (asserts! (map-insert offers-refunded-map id true) ERR_INVALID_OFFER)
+    (try! (as-contract (stx-transfer? (get amount offer) (as-contract tx-sender) (get sender offer))))
+    (print {
+      topic: "offer-refunded",
+      offer: (merge offer { id: id }),
+    })
+    (ok id)
+  )
+)
+
+;; Getters
+
+(define-read-only (get-offer (id uint)) (map-get? offers-map id))
+
+(define-read-only (get-offer-accepted (id uint)) (map-get? offers-accepted-map id))
+
+(define-read-only (get-offer-cancelled (id uint)) (map-get? offers-cancelled-map id))
+
+(define-read-only (get-offer-refunded (id uint)) (map-get? offers-cancelled-map id))
+
+(define-read-only (get-last-id) (var-get last-id-var))
+
+;; Private
+
+(define-private (make-next-id)
+  (let
+    (
+      (last-id (var-get last-id-var))
+    )
+    (var-set last-id-var (+ last-id u1))
+    last-id
+  )
+)

--- a/examples/ordyswap/description.txt
+++ b/examples/ordyswap/description.txt
@@ -1,0 +1,1 @@
+A contract implementing a trustless peer-to-peer atomic swap between Bitcoin Ordinals and STX.

--- a/examples/ordyswap/settings/Devnet.toml
+++ b/examples/ordyswap/settings/Devnet.toml
@@ -1,0 +1,145 @@
+[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+# secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
+# stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+# btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
+
+[accounts.wallet_4]
+mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+balance = 100_000_000_000_000
+# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
+# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
+
+[accounts.wallet_5]
+mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+balance = 100_000_000_000_000
+# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
+# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
+
+[accounts.wallet_6]
+mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+balance = 100_000_000_000_000
+# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+[accounts.wallet_7]
+mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+balance = 100_000_000_000_000
+# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+[accounts.wallet_8]
+mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+balance = 100_000_000_000_000
+# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+[accounts.faucet]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+# disable_bitcoin_explorer = true
+# working_dir = "tmp/devnet"
+# stacks_node_events_observers = ["host.docker.internal:8002"]
+# miner_mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+# miner_derivation_path = "m/44'/5757'/0'/0/0"
+# faucet_mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+# faucet_derivation_path = "m/44'/5757'/0'/0/0"
+# orchestrator_port = 20445
+# bitcoin_node_p2p_port = 18444
+# bitcoin_node_rpc_port = 18443
+# bitcoin_node_username = "devnet"
+# bitcoin_node_password = "devnet"
+# bitcoin_controller_block_time = 30_000
+# stacks_node_rpc_port = 20443
+# stacks_node_p2p_port = 20444
+# stacks_api_port = 3999
+# stacks_api_events_port = 3700
+# bitcoin_explorer_port = 8001
+# stacks_explorer_port = 8000
+# postgres_port = 5432
+# postgres_username = "postgres"
+# postgres_password = "postgres"
+# postgres_database = "postgres"
+# bitcoin_node_image_url = "quay.io/hirosystems/bitcoind:devnet-v2"
+# stacks_node_image_url = "localhost:5000/stacks-node:devnet-v2"
+# stacks_api_image_url = "hirosystems/stacks-blockchain-api:latest"
+# stacks_explorer_image_url = "hirosystems/explorer:latest"
+# bitcoin_explorer_image_url = "quay.io/hirosystems/bitcoin-explorer:devnet"
+# postgres_image_url = "postgres:14"
+# enable_subnet_node = true
+# subnet_node_image_url = "hirosystems/stacks-subnets:0.1.0"
+# subnet_leader_mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+# subnet_leader_derivation_path = "m/44'/5757'/0'/0/0"
+# subnet_contract_id = "STXMJXCJDCT4WPF2X1HE42T6ZCCK3TPMBRZ51JEG.subnet"
+# subnet_node_rpc_port = 30443
+# subnet_node_p2p_port = 30444
+# subnet_events_ingestion_port = 30445
+# subnet_node_events_observers = ["host.docker.internal:8002"]
+
+# For testing in epoch 2.1 / using Clarity2
+# enable_next_features = true
+# epoch_2_0 = 103
+# epoch_2_05 = 104
+# epoch_2_1 = 106
+# pox_2_activation = 109
+
+
+# Send some stacking orders
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_2"
+slots = 1
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_3"
+slots = 1
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"

--- a/examples/ordyswap/tests/ord-swap_test.ts
+++ b/examples/ordyswap/tests/ord-swap_test.ts
@@ -1,0 +1,26 @@
+
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v1.4.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.170.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Ensure that <...>",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        let block = chain.mineBlock([
+            /*
+             * Add transactions with:
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 2);
+
+        block = chain.mineBlock([
+            /*
+             * Add transactions with:
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 3);
+    },
+});


### PR DESCRIPTION
This PR adds an Ordinals-related smart contract to Hiro's set of Clarity examples, taken with permission from the Mechanism's project "Ordyswap": https://github.com/mechanismHQ/ordyswap

Contract is an atomic swap for STX and genesis (never-before transferred) Bitcoin Ordinals.

Solves Issue https://github.com/hirosystems/clarity-examples/issues/4