### PR TITLE
chore: upgrade contracts clarity version and epoch

### DIFF
--- a/examples/clarity-bitcoin/Clarinet.toml
+++ b/examples/clarity-bitcoin/Clarinet.toml
@@ -7,7 +7,8 @@ cache_dir = "./.cache"
 
 [contracts.clarity-bitcoin]
 path = "contracts/clarity-bitcoin.clar"
-clarity_version = 1
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/examples/counter/Clarinet.toml
+++ b/examples/counter/Clarinet.toml
@@ -7,6 +7,8 @@ cache_dir = './.cache'
 
 [contracts.counter]
 path = "contracts/counter.clar"
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/examples/fungible-token/Clarinet.toml
+++ b/examples/fungible-token/Clarinet.toml
@@ -10,7 +10,8 @@ contract_id = "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standa
 
 [contracts.fungible-token]
 path = "contracts/fungible-token.clar"
-clarity_version = 1
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/examples/hello-world/Clarinet.toml
+++ b/examples/hello-world/Clarinet.toml
@@ -5,9 +5,10 @@ authors = []
 telemetry = true
 cache_dir = './.cache'
 
-
 [contracts.hello-world]
 path = "contracts/hello-world.clar"
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/examples/lightning-swaps/Clarinet.toml
+++ b/examples/lightning-swaps/Clarinet.toml
@@ -7,7 +7,8 @@ cache_dir = "./.cache"
 
 [contracts.stxswap_v10]
 path = "contracts/stxswap_v10.clar"
-clarity_version = 1
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = []

--- a/examples/nft-marketplace/Clarinet.toml
+++ b/examples/nft-marketplace/Clarinet.toml
@@ -12,7 +12,8 @@ contract_id = "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standa
 
 [contracts.nft-marketplace]
 path = "contracts/nft-marketplace.clar"
-clarity_version = 1
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = []

--- a/examples/non-fungible-token/Clarinet.toml
+++ b/examples/non-fungible-token/Clarinet.toml
@@ -10,6 +10,8 @@ contract_id = "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait"
 
 [contracts.non-fungible-token]
 path = "contracts/non-fungible-token.clar"
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/examples/ordyswap/Clarinet.toml
+++ b/examples/ordyswap/Clarinet.toml
@@ -10,8 +10,8 @@ contract_id = "SP1WN90HKT0E1FWCJT9JFPMC8YP7XGBGFNZGHRVZX.clarity-bitcoin"
 
 [contracts.ord-swap]
 path = "contracts/ord-swap.clar"
-clarity_version = 1
-epoch = 2.05
+clarity_version = 2
+epoch = 2.4
 
 [repl.analysis]
 passes = []


### PR DESCRIPTION
Upgrade all the example to
```
clarity_version = 2
epoch = 2.4
```

In order to enforce best practices (all new project should use the latest epoch and clarity version)