### PR TITLE
Fix `infinite borrow` vulnerability in `stx-defi`

### DIFF
--- a/examples/stx-defi/contracts/stx-defi.clar
+++ b/examples/stx-defi/contracts/stx-defi.clar
@@ -52,7 +52,7 @@
         ;; Calculate the total amount due including interest.
         (total-due (+ (get amount current-loan-details) (unwrap-panic accrued-interest)))
         ;; Calculate the new loan total after borrowing additional amount.
-        (new-loan (+ amount))
+        (new-loan (+ (get amount current-loan-details) amount))
     )
         ;; Ensure the requested borrow amount does not exceed the allowed amount.
         (asserts! (<= new-loan allowed-borrow) err-overborrow)


### PR DESCRIPTION
This PR fixes a critical bug in the `stx-defi` contract’s `borrow` function, which allows users to drain contract funds by repeatedly borrowing without limits.  

The issue was discovered during a live demo of **Nostradamus**, an auditing assistant for Clarity smart contracts. Nostradamus integrates with any fuzzer but is specifically designed to work with [Rendezvous](https://github.com/stacks-network/rendezvous), the only open-source Clarity fuzzer, ensuring compliance with its property test and invariant formats.  

### Detecting the Bug  
The vulnerability can be caught using the following **property tests**, proposed by Nostradamus and slightly tweaked by the developer (in `stx-defi.tests.clar`):

```clarity
;; Nostradamus Assistant proposed the following property test scenarios to
;; help you foresee your smart contract's future. Use his valuable insights
;; carefully, for your own advantage!

(define-constant ERR_DEPOSIT_FAILED (err u1000))
(define-constant ERR_BORROW_FAILED (err u1001))

(define-public (test-deposit (amount uint))
  (if
    (and (>= (stx-get-balance tx-sender) amount) (> amount u0))
    (let
      (
        (initial-balance
          (default-to u0 (get amount (map-get? deposits { owner: tx-sender })))
        )
      )
      (try! (deposit amount))
      (let
        (
          (updated-balance
            (default-to
              u0
              (get amount (map-get? deposits { owner: tx-sender }))
            )
          )
        )
        (asserts!
          (is-eq (+ initial-balance amount) updated-balance) ERR_DEPOSIT_FAILED
        )
        (ok true)
      )
    )
    (ok false)
  )
)

(define-public (test-borrow (amount uint))
  (if
    (and
      (> amount u0)
      (>= (stx-get-balance tx-sender) amount)
      (<=
        (+ amount)
        (/
          (default-to u0 (get amount (map-get? deposits { owner: tx-sender })))
          u2
        )
      )
    )
    (let
      (
        (initial-loan
          (default-to
            { amount: u0, last-interaction-block: u0 }
            (map-get? loans tx-sender)
          )
        )
      )
      (try! (borrow amount))
      (let
        (
          (updated-loan
            (default-to
              { amount: u0, last-interaction-block: u0 }
              (map-get? loans tx-sender)
            )
          )
        )
        (asserts!
          (is-eq
            (+ (get amount initial-loan) amount)
            (get amount updated-loan)
          )
          ERR_BORROW_FAILED
        )
        (ok true)
      )
    )
    (ok false)
  )
)

```

### Running the Tests  
To run the tests that catch the bug, run:
```sh
npm i @stacks/rendezvous
npx rv <path-to-Clarinet-project> stx-defi test
```

This PR ensures the `borrow` function now properly enforces borrowing limits, preventing fund depletion.